### PR TITLE
DTSW-7445-Fix-dt-ros-interface-high-CPU-usage-bug

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -1,6 +1,2 @@
 # LIST YOUR PYTHON3 PACKAGES HERE
 # NOTE: only place non-Duckietown libraries here; pin versions only if necessary
-
-# Duckietown messages
-duckietown-messages==0.0.24
-dtps-http==1.4.0


### PR DESCRIPTION
This pull request makes a small change to the project's Python 3 dependencies by removing two Duckietown-specific libraries from the `dependencies-py3.txt` file.