### PR TITLE
DTSW-7840 Potential fix for code scanning alert no. 2: Uncontrolled command line

### DIFF
--- a/packages/ros_http_api/include/dt_ros_api/actions/bag.py
+++ b/packages/ros_http_api/include/dt_ros_api/actions/bag.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 import signal
 import datetime
@@ -41,15 +42,53 @@ class ROSBag:
     path: str
     status: Status
 
+TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]$")
+
+
+def _safe_destination_dir(experiment: str):
+    base_dir = os.path.abspath(BAG_RECORDER_DIR)
+    exp = (experiment or "").strip()
+    normalized = os.path.normpath(exp.lstrip('/'))
+    if normalized in ("", ".", "..") or normalized.startswith("../"):
+        return None
+    candidate = os.path.abspath(os.path.join(base_dir, normalized))
+    if os.path.commonpath([base_dir, candidate]) != base_dir:
+        return None
+    return candidate
+
+
+def _safe_topics(raw_topics: str):
+    topics = (raw_topics or "--all").split(":")
+    if len(topics) == 1 and topics[0] == "--all":
+        return topics
+    safe = []
+    for topic in topics:
+        t = topic.strip()
+        if not t:
+            return None
+        # prevent option injection into rosbag arguments
+        if t.startswith('-'):
+            return None
+        if not TOPIC_RE.match(t):
+            return None
+        safe.append(t)
+    return safe
+
 
 @rosbag.route('/bag/record/start/<path:experiment>', methods=['POST', 'GET'])
 def _rosbag_start(experiment: str):
     # record specified topics, or all if not specified
     if request.method == "POST":
-        topics = request.form.get("topics", "--all").split(":")
+        raw_topics = request.form.get("topics", "--all")
     else:
-        topics = request.args.get("topics", "--all").split(":")
-    destination_dir = os.path.join(BAG_RECORDER_DIR, experiment.lstrip('/'))
+        raw_topics = request.args.get("topics", "--all")
+    topics = _safe_topics(raw_topics)
+    if topics is None:
+        return response_error("Invalid topics parameter.")
+
+    destination_dir = _safe_destination_dir(experiment)
+    if destination_dir is None:
+        return response_error("Invalid experiment path.")
     # make sure target directory exists
     subprocess.run(["mkdir", "-p", destination_dir])
     bag_name = datetime.datetime.now().isoformat().replace(':', '_').split('.')[0]


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-ros-interface/security/code-scanning/2](https://github.com/duckietown/dt-ros-interface/security/code-scanning/2)

Use strict validation/normalization on all user-controlled values before they are used in command arguments:

1. **Constrain `experiment`** to a safe relative path under `BAG_RECORDER_DIR`:
   - Normalize with `os.path.normpath`.
   - Reject absolute paths and traversal (`..`).
   - Resolve with `os.path.abspath` and ensure it remains under `BAG_RECORDER_DIR` using `os.path.commonpath`.

2. **Constrain `topics`** to safe rosbag topic tokens:
   - Allow only `--all` or topic names matching a conservative regex (e.g., `/foo/bar`, alnum/underscore with `/` separators).
   - Reject empty entries and option-like values starting with `-` (except exact `--all`).

3. Keep behavior unchanged otherwise (same command structure, same response payload), but return `response_error(...)` for invalid inputs.

Edits are limited to `packages/ros_http_api/include/dt_ros_api/actions/bag.py`: add `import re`, add small helper validators, and use them in `_rosbag_start` before command construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
