### PR TITLE
DTSW-7840 Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/packages/ros_http_api/include/dt_ros_api/actions/logs.py
+++ b/packages/ros_http_api/include/dt_ros_api/actions/logs.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 from datetime import datetime
 
 from flask import Blueprint, send_file
@@ -14,14 +15,20 @@ from dt_ros_api.constants import default_node_info
 _ROBOT_HOSTNAME = get_device_hostname()
 _ROS_LOGS_DIR = "/tmp/log/latest"
 DEFAULT_NODE_INFO = default_node_info()
+_SAFE_NODE_NAME_RE = re.compile(r'^[A-Za-z0-9_]+$')
 
 roslogs = Blueprint('logs', __name__)
 
 
 @roslogs.route('/logs/download/<string:node_name>')
 def _download(node_name: str):
+    if not _SAFE_NODE_NAME_RE.fullmatch(node_name):
+        return response_error("Invalid node name.")
+
     file_pattern = os.path.join(_ROS_LOGS_DIR, f"{_ROBOT_HOSTNAME}-{node_name}-*.log")
     log_files = glob.glob(file_pattern)
+    if not log_files:
+        return response_error(f"No log file found for node '{node_name}'.")
 
     # lex order's last log file, in case there are rolling/truncated logs
     file_path = sorted(log_files, reverse=True)[0]


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-ros-interface/security/code-scanning/5](https://github.com/duckietown/dt-ros-interface/security/code-scanning/5)

The best fix is to validate `node_name` against a strict allowlist of safe characters before using it in any path/glob expression, and reject invalid values early. For ROS-like node identifiers, allowing only alphanumerics and underscores is a safe, minimally disruptive baseline here.

In `packages/ros_http_api/include/dt_ros_api/actions/logs.py`:
- Add `import re`.
- Define a compiled regex (module-level), e.g. `^[A-Za-z0-9_]+$`.
- In `_download`, before building `file_pattern`, validate `node_name`; if invalid, return `response_error(...)`.
- Also safely handle empty `log_files` before indexing `[0]` to avoid unintended exceptions (keeps behavior robust without changing core functionality).

This removes uncontrolled glob/path manipulation while preserving expected download behavior for valid node names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
