### PR TITLE
DTSW-7840 Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/packages/ros_http_api/include/dt_ros_api/actions/logs.py
+++ b/packages/ros_http_api/include/dt_ros_api/actions/logs.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 from datetime import datetime
 
 from flask import Blueprint, send_file
@@ -13,6 +14,7 @@ from dt_ros_api.constants import default_node_info
 
 _ROBOT_HOSTNAME = get_device_hostname()
 _ROS_LOGS_DIR = "/tmp/log/latest"
+_NODE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 DEFAULT_NODE_INFO = default_node_info()
 
 roslogs = Blueprint('logs', __name__)
@@ -20,11 +22,22 @@ roslogs = Blueprint('logs', __name__)
 
 @roslogs.route('/logs/download/<string:node_name>')
 def _download(node_name: str):
+    if not _NODE_NAME_RE.fullmatch(node_name):
+        return response_error("Invalid node name.")
+
     file_pattern = os.path.join(_ROS_LOGS_DIR, f"{_ROBOT_HOSTNAME}-{node_name}-*.log")
-    log_files = glob.glob(file_pattern)
+    base_dir = os.path.realpath(_ROS_LOGS_DIR)
+    safe_log_files = []
+    for fpath in glob.glob(file_pattern):
+        real_fpath = os.path.realpath(fpath)
+        if real_fpath.startswith(base_dir + os.sep):
+            safe_log_files.append(real_fpath)
+
+    if not safe_log_files:
+        return response_error(f"No log file found for node {node_name}.")
 
     # lex order's last log file, in case there are rolling/truncated logs
-    file_path = sorted(log_files, reverse=True)[0]
+    file_path = sorted(safe_log_files, reverse=True)[0]
 
     if os.path.exists(file_path):
         # prepare to rename file when downloading


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-ros-interface/security/code-scanning/4](https://github.com/duckietown/dt-ros-interface/security/code-scanning/4)

To fix this safely without changing intended functionality, validate `node_name` as a strict filename component (allow only expected node-name characters), then canonicalize and verify each matched path remains inside `_ROS_LOGS_DIR` before use. Also handle the empty-match case cleanly.

Best concrete fix in `packages/ros_http_api/include/dt_ros_api/actions/logs.py`:

1. Add `import re`.
2. Add a module-level allowlist regex for node names (for example: letters, digits, underscore, dot, hyphen).
3. In `_download`:
   - Reject invalid `node_name` early with `response_error`.
   - Build `file_pattern` only after validation.
   - Filter glob results by resolving real paths and ensuring they start with canonical `_ROS_LOGS_DIR` + separator.
   - Return a clear error if no matching safe log file exists.
   - Use the filtered list to pick the latest file.

This preserves endpoint behavior (download latest node log) while preventing uncontrolled path usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
