### PR TITLE
DTSW-7840 Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-pr-check.yml
+++ b/.github/workflows/jira-pr-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-jira-key:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-ros-interface/security/code-scanning/1](https://github.com/duckietown/dt-ros-interface/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged.

Best fix here (without changing behavior): define workflow-level read-only permissions, since this workflow only validates PR title/branch text and does not need write scopes.

**File to edit:** `.github/workflows/jira-pr-check.yml`  
**Change:** insert at workflow root (after `on:` block, before `jobs:`):

- `permissions:`
  - `contents: read`
  - `pull-requests: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
