### PR TITLE
DTSW-7840 Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/packages/ros_http_api/include/dt_ros_api/actions/bag.py
+++ b/packages/ros_http_api/include/dt_ros_api/actions/bag.py
@@ -162,8 +162,8 @@ def _rosbag_delete(bag_name: str):
     # delete recording
     try:
         os.remove(bag.path)
-    except BaseException as e:
-        return response_error(f"Error: {str(e)}")
+    except BaseException:
+        return response_error("An internal error has occurred.")
     # return current API rosbag
     return response_ok({
         'name': bag_name

--- a/packages/ros_http_api/include/dt_ros_api/actions/graph.py
+++ b/packages/ros_http_api/include/dt_ros_api/actions/graph.py
@@ -110,5 +110,5 @@ def _graph():
             'nodes': nodes,
             'topics': topics
         })
-    except Exception as e:
-        return response_error(str(e))
+    except Exception:
+        return response_error("An internal error has occurred.")

--- a/packages/ros_http_api/include/dt_ros_api/actions/node.py
+++ b/packages/ros_http_api/include/dt_ros_api/actions/node.py
@@ -34,8 +34,8 @@ def _list():
         return response_ok({
             'nodes': sorted(KnowledgeBase.get('/node/list', []))
         })
-    except Exception as e:
-        return response_error(str(e))
+    except Exception:
+        return response_error("An internal error has occurred.")
 
 
 @rosnode.route('/node/info/<path:node>')
@@ -56,8 +56,8 @@ def _info(node):
         # get services
         info['parameters'] = KnowledgeBase.get(key('params'), [])
         return response_ok(info)
-    except Exception as e:
-        return response_error(str(e))
+    except Exception:
+        return response_error("An internal error has occurred.")
 
 
 @rosnode.route('/node/topics/<path:node>')
@@ -71,8 +71,8 @@ def _topics(node):
                 } for t_name, t_info in KnowledgeBase.get('/node/topics/%s' % node, {}).items()
             }
         })
-    except Exception as e:
-        return response_error(str(e))
+    except Exception:
+        return response_error("An internal error has occurred.")
 
 
 @rosnode.route('/node/params/<path:node>')
@@ -82,8 +82,8 @@ def _params(node):
             'node': '/' + node,
             'parameters': KnowledgeBase.get('/node/params/%s' % node, {})
         })
-    except Exception as e:
-        return response_error(str(e))
+    except Exception:
+        return response_error("An internal error has occurred.")
 
 
 @rosnode.route('/node/services/<path:node>')
@@ -93,5 +93,5 @@ def _services(node):
             'node': '/' + node,
             'services': KnowledgeBase.get('/node/services/%s' % node, {})
         })
-    except Exception as e:
-        return response_error(str(e))
+    except Exception:
+        return response_error("An internal error has occurred.")


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-ros-interface/security/code-scanning/3](https://github.com/duckietown/dt-ros-interface/security/code-scanning/3)

The correct fix is to stop returning raw exception text to clients and return a generic, non-sensitive error message instead, while optionally logging details server-side. Since we should avoid assuming logging infrastructure outside shown snippets, the safest minimal fix is to replace all `response_error(str(e))` and similar exception-derived responses with constant messages.

Best single approach without changing functionality:
- In `packages/ros_http_api/include/dt_ros_api/actions/bag.py`, update the `except BaseException as e` block in `_rosbag_delete` to return a generic message and avoid using `e` in the response.
- In `packages/ros_http_api/include/dt_ros_api/actions/graph.py`, update `_graph`’s `except Exception as e` block similarly.
- In `packages/ros_http_api/include/dt_ros_api/actions/node.py`, update all `except Exception as e` handlers to return the same generic message.
- No changes are required in `utils.py`; the sink is generic and should remain reusable. The remediation is at call sites that pass tainted exception content.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
